### PR TITLE
fix: simplify typedoc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Lint:
 
 Generate HTML API Documentation:
 
-`bunx typedoc --readme none index.ts`
+`bunx typedoc index.ts`
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,11 @@
   "peerDependencies": {
     "typescript": "^6.0.3"
   },
-  "ffiLibBaseUri": "https://github.com/flowscripter/template-bun-rust-library/releases/download/v1.1.3"
+  "ffiLibBaseUri": "https://github.com/flowscripter/template-bun-rust-library/releases/download/v1.1.3",
+  "typedocOptions": {
+    "readme": "none",
+    "exclude": [
+      "tests/**"
+    ]
+  }
 }


### PR DESCRIPTION
Move typedoc options to package.json so the CLI command is simply `bunx typedoc index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)