### PR TITLE
fix: use URL constructor instead of path.join for FFI lib download URL

### DIFF
--- a/src/lib-path.ts
+++ b/src/lib-path.ts
@@ -41,7 +41,10 @@ export async function getLibPath(libName: string) {
   console.debug(`packageJson.ffiLibBaseUri: ${packageJson.ffiLibBaseUri}`);
 
   // look in release download location
-  const remotePath = path.join(packageJson.ffiLibBaseUri, fullLibName);
+  const base = packageJson.ffiLibBaseUri.endsWith("/")
+    ? packageJson.ffiLibBaseUri
+    : packageJson.ffiLibBaseUri + "/";
+  const remotePath = new URL(fullLibName, base).href;
 
   console.debug(`remotePath: ${remotePath}`);
 


### PR DESCRIPTION
## Summary

- `path.join()` normalises double slashes, corrupting `https://` into `https:/` on Linux
- This caused the FFI `.so` download to fetch a malformed URL, writing an HTML error page to disk instead of the binary
- `dlopen` then failed with `file too short`
- Fixed by using `new URL(fullLibName, base)` which handles URL joining correctly and is robust against a trailing slash on `ffiLibBaseUri`

## Test plan

- [ ] Verify CI passes with the updated dependency in `template-bun-executable`
- [ ] Confirm `remotePath` in debug output shows a valid `https://` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)