### PR TITLE
fix: use arch-specific remote filename when downloading FFI lib

### DIFF
--- a/src/lib-path.ts
+++ b/src/lib-path.ts
@@ -41,10 +41,24 @@ export async function getLibPath(libName: string) {
   console.debug(`packageJson.ffiLibBaseUri: ${packageJson.ffiLibBaseUri}`);
 
   // look in release download location
+  // release asset naming differs from the local dlopen name:
+  //   Linux:   {arch}.so       (e.g. x64.so, arm64.so)
+  //   macOS:   lib{name}.dylib (unchanged)
+  //   Windows: {name}.{arch}.dll
+  const arch = process.arch;
+  let remoteLibName: string;
+  if (suffix === "so") {
+    remoteLibName = `${arch}.${suffix}`;
+  } else if (suffix === "dll") {
+    remoteLibName = `${libName}.${arch}.${suffix}`;
+  } else {
+    remoteLibName = fullLibName;
+  }
+
   const base = packageJson.ffiLibBaseUri.endsWith("/")
     ? packageJson.ffiLibBaseUri
     : packageJson.ffiLibBaseUri + "/";
-  const remotePath = new URL(fullLibName, base).href;
+  const remotePath = new URL(remoteLibName, base).href;
 
   console.debug(`remotePath: ${remotePath}`);
 

--- a/src/lib-path.ts
+++ b/src/lib-path.ts
@@ -41,7 +41,10 @@ export async function getLibPath(libName: string) {
   console.debug(`packageJson.ffiLibBaseUri: ${packageJson.ffiLibBaseUri}`);
 
   // look in release download location
-  const remotePath = path.join(packageJson.ffiLibBaseUri, fullLibName);
+  const base = packageJson.ffiLibBaseUri.endsWith("/")
+    ? packageJson.ffiLibBaseUri
+    : packageJson.ffiLibBaseUri + "/";
+  const remotePath = new URL(fullLibName, base).href;
 
   console.debug(`remotePath: ${remotePath}`);
 

--- a/src/lib-path.ts
+++ b/src/lib-path.ts
@@ -4,12 +4,24 @@ import path from "node:path";
 import { mkdir } from "node:fs/promises";
 import packageJson from "../package.json";
 
-export async function getLibPath(libName: string) {
-  let fullLibName = libName + "." + suffix;
+export function buildLocalLibName(libName: string, libSuffix: string): string {
+  const base = `${libName}.${libSuffix}`;
+  return libSuffix === "dll" ? base : `lib${base}`;
+}
 
-  if (suffix !== "dll") {
-    fullLibName = "lib" + fullLibName;
-  }
+export function buildRemoteLibName(libName: string, libSuffix: string, arch: string): string {
+  if (libSuffix === "so") return `${arch}.${libSuffix}`;
+  if (libSuffix === "dll") return `${libName}.${arch}.${libSuffix}`;
+  return buildLocalLibName(libName, libSuffix);
+}
+
+export function buildRemoteUrl(baseUri: string, remoteLibName: string): string {
+  const base = baseUri.endsWith("/") ? baseUri : baseUri + "/";
+  return new URL(remoteLibName, base).href;
+}
+
+export async function getLibPath(libName: string) {
+  const fullLibName = buildLocalLibName(libName, suffix);
 
   // look in release build location
   const builtLibPath = path.join("target", "release", fullLibName);
@@ -40,25 +52,8 @@ export async function getLibPath(libName: string) {
 
   console.debug(`packageJson.ffiLibBaseUri: ${packageJson.ffiLibBaseUri}`);
 
-  // look in release download location
-  // release asset naming differs from the local dlopen name:
-  //   Linux:   {arch}.so       (e.g. x64.so, arm64.so)
-  //   macOS:   lib{name}.dylib (unchanged)
-  //   Windows: {name}.{arch}.dll
-  const arch = process.arch;
-  let remoteLibName: string;
-  if (suffix === "so") {
-    remoteLibName = `${arch}.${suffix}`;
-  } else if (suffix === "dll") {
-    remoteLibName = `${libName}.${arch}.${suffix}`;
-  } else {
-    remoteLibName = fullLibName;
-  }
-
-  const base = packageJson.ffiLibBaseUri.endsWith("/")
-    ? packageJson.ffiLibBaseUri
-    : packageJson.ffiLibBaseUri + "/";
-  const remotePath = new URL(remoteLibName, base).href;
+  const remoteLibName = buildRemoteLibName(libName, suffix, process.arch);
+  const remotePath = buildRemoteUrl(packageJson.ffiLibBaseUri, remoteLibName);
 
   console.debug(`remotePath: ${remotePath}`);
 

--- a/tests/lib_path_test.ts
+++ b/tests/lib_path_test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { buildLocalLibName, buildRemoteLibName, buildRemoteUrl } from "../src/lib-path.ts";
+
+describe("buildLocalLibName", () => {
+  test("Linux .so gets lib prefix", () => {
+    expect(buildLocalLibName("foo", "so")).toBe("libfoo.so");
+  });
+
+  test("macOS .dylib gets lib prefix", () => {
+    expect(buildLocalLibName("foo", "dylib")).toBe("libfoo.dylib");
+  });
+
+  test("Windows .dll has no lib prefix", () => {
+    expect(buildLocalLibName("foo", "dll")).toBe("foo.dll");
+  });
+});
+
+describe("buildRemoteLibName", () => {
+  test("Linux x64", () => {
+    expect(buildRemoteLibName("foo", "so", "x64")).toBe("x64.so");
+  });
+
+  test("Linux arm64", () => {
+    expect(buildRemoteLibName("foo", "so", "arm64")).toBe("arm64.so");
+  });
+
+  test("macOS uses local naming (no arch suffix)", () => {
+    expect(buildRemoteLibName("foo", "dylib", "arm64")).toBe("libfoo.dylib");
+    expect(buildRemoteLibName("foo", "dylib", "x64")).toBe("libfoo.dylib");
+  });
+
+  test("Windows x64", () => {
+    expect(buildRemoteLibName("foo", "dll", "x64")).toBe("foo.x64.dll");
+  });
+
+  test("Windows arm64", () => {
+    expect(buildRemoteLibName("foo", "dll", "arm64")).toBe("foo.arm64.dll");
+  });
+});
+
+describe("buildRemoteUrl", () => {
+  test("base without trailing slash", () => {
+    expect(buildRemoteUrl("https://example.com/releases/v1.0", "x64.so")).toBe(
+      "https://example.com/releases/v1.0/x64.so",
+    );
+  });
+
+  test("base with trailing slash", () => {
+    expect(buildRemoteUrl("https://example.com/releases/v1.0/", "x64.so")).toBe(
+      "https://example.com/releases/v1.0/x64.so",
+    );
+  });
+
+  test("does not corrupt https:// into https:/", () => {
+    const url = buildRemoteUrl("https://github.com/org/repo/releases/download/v1.0", "x64.so");
+    expect(url).toBe("https://github.com/org/repo/releases/download/v1.0/x64.so");
+    expect(url.startsWith("https://")).toBe(true);
+  });
+
+  test("real-world example matches expected release asset URL", () => {
+    const url = buildRemoteUrl(
+      "https://github.com/flowscripter/template-bun-rust-library/releases/download/v1.1.5",
+      "x64.so",
+    );
+    expect(url).toBe(
+      "https://github.com/flowscripter/template-bun-rust-library/releases/download/v1.1.5/x64.so",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Since multi-arch support was added, release assets use a different naming scheme from the local `dlopen` filename:
  - Linux: `x64.so` / `arm64.so`
  - macOS: `lib{name}.dylib` (unchanged)
  - Windows: `{name}.x64.dll` / `{name}.arm64.dll`
- The code was still requesting the old single-name path (e.g. `libflowscripter_template_bun_rust_library.so`) which 404s on newer releases, writing an HTML error page to disk
- `dlopen` then failed with `file too short`
- Fixed by deriving `remoteLibName` from `process.arch` and `suffix` separately from the local `fullLibName` used for `dlopen`

## Test plan

- [ ] Verify CI passes on `template-bun-executable` after this releases as a new version
- [ ] Confirm `remotePath` debug log shows e.g. `.../x64.so` on Linux x64

🤖 Generated with [Claude Code](https://claude.com/claude-code)