### PR TITLE
feat: add build step for Node.js and TypeScript consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Install dependencies:
 
 `bun install`
 
+Build (produces `dist/` for Node.js and TypeScript consumers; Bun uses raw source directly):
+
+`bun run build`
+
 Test:
 
 `cargo test`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
     "type": "git",
     "url": "git+https://github.com/flowscripter/template-bun-rust-library.git"
   },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -27,18 +34,11 @@
       "default": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "src",
-    "index.ts",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "build": "bun build index.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
-  },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "bun build index.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,26 @@
     "url": "git+https://github.com/flowscripter/template-bun-rust-library.git"
   },
   "type": "module",
-  "module": "index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "index.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "bun build index.ts --outdir dist --target bun && tsc -p tsconfig.build.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `bun run build` script: runs `bun build index.ts --outdir dist --target bun` then `tsc -p tsconfig.build.json`
- Add `tsconfig.build.json` extending the base config with `emitDeclarationOnly`, `declaration`, `declarationMap`, `rewriteRelativeImportExtensions`, and `outDir: dist`
- Update `package.json` with `main`, `types`, `exports` (with `bun` condition for raw source), and `files` fields
- Update README with build step documentation

Bun consumers use raw `.ts` source via the `bun` exports condition. Node.js and TypeScript consumers use `dist/index.js` and `dist/index.d.ts`.

## Test plan

- [ ] `bun install && bun run build` produces `dist/index.js` and `dist/index.d.ts`
- [ ] CI workflow runs `bun run build` before semantic-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)