### PR TITLE
chore: add dist to tsconfig ignore list

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
   },
-  "exclude": ["tests"]
+  "exclude": ["tests", "dist"]
 }


### PR DESCRIPTION
## Summary
- Add `dist` to the `exclude` list in `tsconfig.json` to prevent TypeScript from checking build output files

## Test plan
- [ ] Verify `tsconfig.json` excludes `dist` directory
- [ ] Confirm TypeScript compilation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)